### PR TITLE
Delphi Make Dictionary Static and Dont initialize Array.

### DIFF
--- a/PrimeDelphi/solution_1/PrimePas.dpr
+++ b/PrimeDelphi/solution_1/PrimePas.dpr
@@ -81,7 +81,7 @@ begin
 	begin
 		r:=factor AND $1;
 		num:=factor SHR 1;
-		while num<FSieveSize2 do
+		while num<FSieveSizeSqrt do
 		begin
 			if (not FBitArray[num]) then   // logic is reversed to avoid initializer
 			begin

--- a/PrimeDelphi/solution_1/PrimePas.dpr
+++ b/PrimeDelphi/solution_1/PrimePas.dpr
@@ -17,12 +17,6 @@ var
 	MyDict : TDictionary<NativeInt, NativeInt>;
 
 type
-  ReverseByteBool = ByteBool;
-
-  TReverseByteBoolHelper = Record Helper for ReverseByteBool
-    function AsBool: ByteBool;
-    procedure SetBool(ABool: ByteBool);
-  End;
 
 	TPrimeSieve = class
 	private
@@ -180,18 +174,6 @@ begin
 	MyDict.Add(  1000000, 78498);
 	MyDict.Add( 10000000, 664579);
 	MyDict.Add(100000000, 5761455);
-end;
-
-{ TReverseByteBoolHelper }
-
-function TReverseByteBoolHelper.AsBool: ByteBool;
-begin
-  result := not self;
-end;
-
-procedure TReverseByteBoolHelper.SetBool(ABool: ByteBool);
-begin
-  self := not ABool;
 end;
 
 {

--- a/PrimeDelphi/solution_1/PrimePas.dpr
+++ b/PrimeDelphi/solution_1/PrimePas.dpr
@@ -13,6 +13,9 @@ uses
   Math,
   Windows;
 
+var
+	MyDict : TDictionary<NativeInt, NativeInt>;
+
 type
 	TPrimeSieve = class
 	private
@@ -20,12 +23,10 @@ type
 		FSieveSize2: NativeInt;
 		FSieveSizeSqrt: NativeInt;
 		FBitArray: array of ByteBool; //ByteBool: 4644. WordBool: 4232. LongBool: 3673
-		FMyDict: TDictionary<NativeInt, NativeInt>;
 
 		procedure InitializeBits;
 	public
 		constructor Create(Size: Integer);
-		destructor Destroy; override;
 
 		procedure RunSieve; // Calculate the primes up to the specified limit
 
@@ -51,26 +52,6 @@ begin
 	//GetBit and SetBit do the work of "div 2"
 	SetLength(FBitArray, FSieveSize2);
 	InitializeBits;
-
-	FMyDict := TDictionary<NativeInt, NativeInt>.Create;
-
-	// Historical data for validating our results - the number of primes
-	// to be found under some limit, such as 168 primes under 1000
-	FMyDict.Add(       10, 4); //nobody noticed that 1 is wrong? [2, 3, 5, 7]
-	FMyDict.Add(      100, 25);
-	FMyDict.Add(     1000, 168);
-	FMyDict.Add(    10000, 1229);
-	FMyDict.Add(   100000, 9592);
-	FMyDict.Add(  1000000, 78498);
-	FMyDict.Add( 10000000, 664579);
-	FMyDict.Add(100000000, 5761455);
-end;
-
-destructor TPrimeSieve.Destroy;
-begin
-	FreeAndNil(FMyDict);
-
-	inherited;
 end;
 
 function TPrimeSieve.CountPrimes: Integer;
@@ -90,8 +71,8 @@ end;
 
 function TPrimeSieve.ValidateResults: Boolean;
 begin
-	if FMyDict.ContainsKey(FSieveSize) then
-		Result := FMyDict[FSieveSize] = Self.CountPrimes
+	if MyDict.ContainsKey(FSieveSize) then
+		Result := MyDict[FSieveSize] = Self.CountPrimes
 	else
 		Result := False;
 end;
@@ -215,6 +196,22 @@ begin
 		sieve.PrintResults(False, tD.TotalSeconds, passes);
 end;
 
+Procedure InitStaticDictionary;
+begin
+	MyDict := TDictionary<NativeInt, NativeInt>.Create;
+
+	// Historical data for validating our results - the number of primes
+	// to be found under some limit, such as 168 primes under 1000
+	MyDict.Add(       10, 4); //nobody noticed that 1 is wrong? [2, 3, 5, 7]
+	MyDict.Add(      100, 25);
+	MyDict.Add(     1000, 168);
+	MyDict.Add(    10000, 1229);
+	MyDict.Add(   100000, 9592);
+	MyDict.Add(  1000000, 78498);
+	MyDict.Add( 10000000, 664579);
+	MyDict.Add(100000000, 5761455);
+end;
+
 {
 	Intel Core i5-9400 @ 2.90 GHz
 	- 32-bit: 4,809 passes
@@ -236,6 +233,7 @@ end;
 }
 begin
 	try
+    InitStaticDictionary;
 		Main;
 		WriteLn('Press enter to close...');
 		Readln;


### PR DESCRIPTION
## Description
Changed the Dictionary to a static object.

As pointed out by Dave Plummer in the most recent (Delphi Vs Ada)[https://www.youtube.com/watch?v=tQtFdsEcK_s&t=31s] video, this original implementation creates the History Dictionary dynamically each time when it should be static.  This means it does not need to create or destroy the history as a private member.

I also eliminated the need to re-initialize the FBitarray with TRUE which was a significant bottleneck.

## Contributing requirements

* [/ ] I read the contribution guidelines in CONTRIBUTING.md.
* [/ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [ ] I selected `drag-race` as the target branch.
* [/ ] All code herein is licensed compatible with BSD-3.
